### PR TITLE
feat(utils): support newline after multiline comment

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 const oneLineRegex = /^\/\/(.*?)\n?$/;
-const multiLineRegex = /^\/\*([\s\S]*?)\*\/$/;
+const multiLineRegex = /^\/\*([\s\S]*?)\*\/\n?$/;
 
 function isComment( input ) {
 	if ( oneLineRegex.test( input ) || multiLineRegex.test( input ) ) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -34,6 +34,7 @@ describe( 'isComment', () => {
 			'/**/',
 			'/*\n*/',
 			'/*T\ne\ns\nt */',
+			'/*T\ne\ns\nt */\n',
 			'//test',
 			'//Test\n',
 			'// test',


### PR DESCRIPTION
Currently we read our multiline banner text from a text file. We always have a newline at the end of all our files, which means when we take the content of the file and provide it to babel-plugin-banner, it throws an error saying it's an invalid comment. It seems like a good idea to support a newline at the end of a multiline comment, similar to what's already being done for a single line comment.